### PR TITLE
Remove incomplete rows.

### DIFF
--- a/docs/modules/ROOT/pages/clc.adoc
+++ b/docs/modules/ROOT/pages/clc.adoc
@@ -99,7 +99,6 @@ Parameters:
 |`MAPPING`
 |Optional
 |Name of the mapping.
-|
 
 |===
 
@@ -122,6 +121,5 @@ Parameters:
 |`MAPPING`
 |Optional
 |Name of the mapping.
-|
 
 |====


### PR DESCRIPTION
Incomplete rows are causing errors on MC docs:
```
[11:43:35.915] ERROR (asciidoctor): dropping cells from incomplete row detected end of table
    file: docs/modules/ROOT/pages/clc.adoc:127
    source: https://github.com/hazelcast/clc-docs (branch: main | start path: docs)
```
https://github.com/hazelcast/management-center-docs/actions/runs/9447581435/job/26020018646?pr=328