### PR TITLE
Replace versioned Hazelcast docs with `latest`

### DIFF
--- a/docs/modules/ROOT/pages/clc-map.adoc
+++ b/docs/modules/ROOT/pages/clc-map.adoc
@@ -210,7 +210,7 @@ Returns a view of the entry with the given key.
 This command doesn't affect entry statistics, such as Hits and entry metadata such as Max Idle.
 
 See this documentation for information about per-entry statistics:
-link:https://docs.hazelcast.com/hazelcast/5.3/data-structures/reading-map-metrics#getting-statistics-about-a-specific-map-entry[Getting Statistics about a Specific Map Entry].
+link:https://docs.hazelcast.com/hazelcast/latest/data-structures/reading-map-metrics#getting-statistics-about-a-specific-map-entry[Getting Statistics about a Specific Map Entry].
 
 The following information about the entry is returned:
 

--- a/docs/modules/ROOT/pages/install-clc.adoc
+++ b/docs/modules/ROOT/pages/install-clc.adoc
@@ -1,7 +1,7 @@
 = Installing the Hazelcast CLC
 :description: The Hazelcast Command-Line Client (CLC) is available to install in macOS, Linux, and Windows environments.
 
-// See https://docs.hazelcast.com/hazelcast/5.3-snapshot/clients/clc#installing-the-hazelcast-clc
+// See https://docs.hazelcast.com/hazelcast/latest/clients/clc#installing-the-hazelcast-clc
 
 {description} You can install the Hazelcast CLC, using one of the following:
 


### PR DESCRIPTION
Updated existing Hazelcast `5.x` documentation links to use `latest` instead