### PR TITLE
Fix build errors v/5.3.4

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -16,6 +16,6 @@ asciidoc:
     page-toclevels: 3@
     # Required Go version for build
     go-version: 1.21
-    page-latest-supported-mc: '5.5-snapshot'
+    page-latest-supported-mc: '5.5'
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/pages/clc.adoc
+++ b/docs/modules/ROOT/pages/clc.adoc
@@ -124,4 +124,4 @@ Parameters:
 |Name of the mapping.
 |
 
-|====
+|===

--- a/docs/modules/ROOT/pages/install-clc.adoc
+++ b/docs/modules/ROOT/pages/install-clc.adoc
@@ -145,7 +145,7 @@ sudo mv ./build/clc /usr/local/bin
 
 The Hazelcast CLC runs on any recent Linux distribution. We test it on Ubuntu 22.04.
 
-[tabs] 
+[tabs]
 ====
 Install Script (AMD64)::
 +
@@ -203,8 +203,8 @@ sudo mv ./build/clc /usr/local/bin
 
 The Hazelcast CLC is supported on Windows 10 or newer versions. We provide pre-built binaries only for 64bit Intel/AMD architecture.
 
-[tabs] 
-==== 
+[tabs]
+====
 Installer::
 +
 . Go to the https://github.com/hazelcast/hazelcast-commandline-client/releases[releases page], and locate the Windows installer file (`hazelcast-clc-setup-v{full-version}.exe`).
@@ -217,6 +217,7 @@ Installer::
 ----
 clc.exe
 ----
+====
 
 endif::[]
 == Verifying the Hazelcast CLC Installation
@@ -234,8 +235,8 @@ If installed, the Hazelcast CLC version information displays.
 
 Choose the option that corresponds to your installation method.
 
-[tabs] 
-==== 
+[tabs]
+====
 Windows::
 +
 . Go to *Apps & Features* setting (*Start menu* -> *Windows Settings* -> *Apps*).


### PR DESCRIPTION
Fixes

```
[14:44:10.797] WARN (asciidoctor): unterminated table block
5:44:10 PM:     file: docs/modules/ROOT/pages/clc.adoc:119
5:44:10 PM:     source: https://github.com/hazelcast/clc-docs (branch: v/5.3.4 | start path: docs)
5:44:10 PM: [14:44:10.800] ERROR (asciidoctor): dropping cells from incomplete row detected end of table
5:44:10 PM:     file: docs/modules/ROOT/pages/clc.adoc:127
5:44:10 PM:     source: https://github.com/hazelcast/clc-docs (branch: v/5.3.4 | start path: docs)
5:44:10 PM: [14:44:10.952] ERROR (asciidoctor): target of xref not found: 5.5-snapshot@management-center:clusters:clients.adoc
5:44:10 PM:     file: docs/modules/ROOT/pages/environment-variables.adoc
5:44:10 PM:     source: https://github.com/hazelcast/clc-docs (branch: v/5.3.4 | start path: docs)
5:44:11 PM: [14:44:11.037] WARN (asciidoctor): unterminated example block
5:44:11 PM:     file: docs/modules/ROOT/pages/install-clc.adoc:249
5:44:11 PM:     source: https://github.com/hazelcast/clc-docs (branch: v/5.3.4 | start path: docs)
```

https://app.netlify.com/sites/nifty-wozniak-71a44b/deploys/66df085b07c0380008463b10#L276