### PR TITLE
Fix build errors v/5.3.5

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -5,7 +5,7 @@ start_page: overview.adoc
 version: '5.3.5'
 # Version in the version selector (we display only the latest major.minor version)
 display_version: '5.3.5'
-# Displays a banner to inform users that this is a prerelease version 
+# Displays a banner to inform users that this is a prerelease version
 prerelease: false
 asciidoc:
   attributes:
@@ -17,6 +17,6 @@ asciidoc:
     page-toclevels: 3@
     # Required Go version for build
     go-version: 1.21
-    page-latest-supported-mc: '5.5-snapshot'
+    page-latest-supported-mc: '5.5'
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/pages/alias.adoc
+++ b/docs/modules/ROOT/pages/alias.adoc
@@ -49,7 +49,6 @@ Parameters:
 |
 |
 
-|
 |===
 
 Examples:
@@ -88,7 +87,6 @@ Parameters:
 |Name of the alias.
 |
 
-|
 |===
 
 Example:

--- a/docs/modules/ROOT/pages/clc.adoc
+++ b/docs/modules/ROOT/pages/clc.adoc
@@ -124,4 +124,4 @@ Parameters:
 |Name of the mapping.
 |
 
-|====
+|===

--- a/docs/modules/ROOT/pages/install-clc.adoc
+++ b/docs/modules/ROOT/pages/install-clc.adoc
@@ -81,7 +81,7 @@ sudo mv ./build/clc /usr/local/bin
 
 The Hazelcast CLC runs on any recent Linux distribution. We test it on Ubuntu 22.04.
 
-[tabs] 
+[tabs]
 ====
 Install Script (AMD64)::
 +
@@ -139,8 +139,8 @@ sudo mv ./build/clc /usr/local/bin
 
 The Hazelcast CLC is supported on Windows 10 or newer versions. We provide pre-built binaries only for 64bit Intel/AMD architecture.
 
-[tabs] 
-==== 
+[tabs]
+====
 Installer::
 +
 . Go to the https://github.com/hazelcast/hazelcast-commandline-client/releases[releases page], and locate the Windows installer file (`hazelcast-clc-setup-v{full-version}.exe`).
@@ -153,6 +153,7 @@ Installer::
 ----
 clc.exe
 ----
+====
 
 == Verifying the Hazelcast CLC Installation
 
@@ -169,8 +170,8 @@ If installed, the Hazelcast CLC version information displays.
 
 Choose the option that corresponds to your installation method.
 
-[tabs] 
-==== 
+[tabs]
+====
 Windows::
 +
 . Go to *Apps & Features* setting (*Start menu* -> *Windows Settings* -> *Apps*).


### PR DESCRIPTION
Fixes
```
5:05:53 PM: [14:05:53.122] ERROR (asciidoctor): dropping cells from incomplete row detected end of table
5:05:53 PM:     file: docs/modules/ROOT/pages/alias.adoc:52
5:05:53 PM:     source: https://github.com/hazelcast/clc-docs (branch: v/5.3.5 | start path: docs)
5:05:53 PM: [14:05:53.127] ERROR (asciidoctor): dropping cells from incomplete row detected end of table
5:05:53 PM:     file: docs/modules/ROOT/pages/alias.adoc:91
5:05:53 PM:     source: https://github.com/hazelcast/clc-docs (branch: v/5.3.5 | start path: docs)
5:05:54 PM: [14:05:54.096] WARN (asciidoctor): unterminated table block
5:05:54 PM:     file: docs/modules/ROOT/pages/clc.adoc:119
5:05:54 PM:     source: https://github.com/hazelcast/clc-docs (branch: v/5.3.5 | start path: docs)
5:05:54 PM: [14:05:54.101] ERROR (asciidoctor): dropping cells from incomplete row detected end of table
5:05:54 PM:     file: docs/modules/ROOT/pages/clc.adoc:127
5:05:54 PM:     source: https://github.com/hazelcast/clc-docs (branch: v/5.3.5 | start path: docs)
5:05:54 PM: [14:05:54.251] ERROR (asciidoctor): target of xref not found: 5.5-snapshot@management-center:clusters:clients.adoc
5:05:54 PM:     file: docs/modules/ROOT/pages/environment-variables.adoc
5:05:54 PM:     source: https://github.com/hazelcast/clc-docs (branch: v/5.3.5 | start path: docs)
5:05:54 PM: [14:05:54.305] WARN (asciidoctor): unterminated example block
5:05:54 PM:     file: docs/modules/ROOT/pages/install-clc.adoc:184
5:05:54 PM:     source: https://github.com/hazelcast/clc-docs (branch: v/5.3.5 | start path: docs)
```

https://app.netlify.com/sites/nifty-wozniak-71a44b/deploys/66e050c9b9be6f00084f11ce#L288