### PR TITLE
Fix build errors v/5.3.6

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -5,7 +5,7 @@ start_page: overview.adoc
 version: '5.3.6'
 # Version in the version selector (we display only the latest major.minor version)
 display_version: '5.3.6'
-# Displays a banner to inform users that this is a prerelease version 
+# Displays a banner to inform users that this is a prerelease version
 prerelease: false
 asciidoc:
   attributes:
@@ -17,6 +17,6 @@ asciidoc:
     page-toclevels: 3@
     # Required Go version for build
     go-version: 1.21
-    page-latest-supported-mc: '5.5-snapshot'
+    page-latest-supported-mc: '5.5'
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/pages/clc.adoc
+++ b/docs/modules/ROOT/pages/clc.adoc
@@ -124,4 +124,4 @@ Parameters:
 |Name of the mapping.
 |
 
-|====
+|===


### PR DESCRIPTION
Fixes

```
5:05:55 PM: [14:05:55.740] WARN (asciidoctor): unterminated table block
5:05:55 PM:     file: docs/modules/ROOT/pages/clc.adoc:119
5:05:55 PM:     source: https://github.com/hazelcast/clc-docs (branch: v/5.3.6 | start path: docs)
5:05:55 PM: [14:05:55.742] ERROR (asciidoctor): dropping cells from incomplete row detected end of table
5:05:55 PM:     file: docs/modules/ROOT/pages/clc.adoc:127
5:05:55 PM:     source: https://github.com/hazelcast/clc-docs (branch: v/5.3.6 | start path: docs)
5:05:55 PM: [14:05:55.905] ERROR (asciidoctor): target of xref not found: 5.5-snapshot@management-center:clusters:clients.adoc
5:05:55 PM:     file: docs/modules/ROOT/pages/environment-variables.adoc
5:05:55 PM:     source: https://github.com/hazelcast/clc-docs (branch: v/5.3.6 | start path: docs)
```

https://app.netlify.com/sites/nifty-wozniak-71a44b/deploys/66e050c9b9be6f00084f11ce#L306