### PR TITLE
Fix build errors v/5.4.0

### DIFF
--- a/docs/modules/ROOT/pages/clc.adoc
+++ b/docs/modules/ROOT/pages/clc.adoc
@@ -124,4 +124,4 @@ Parameters:
 |Name of the mapping.
 |
 
-|====
+|===


### PR DESCRIPTION
Fixes

```
5:05:59 PM: [14:05:59.434] WARN (asciidoctor): unterminated table block
5:05:59 PM:     file: docs/modules/ROOT/pages/clc.adoc:119
5:05:59 PM:     source: https://github.com/hazelcast/clc-docs (branch: v/5.4.0 | start path: docs)
5:05:59 PM: [14:05:59.437] ERROR (asciidoctor): dropping cells from incomplete row detected end of table
5:05:59 PM:     file: docs/modules/ROOT/pages/clc.adoc:127
5:05:59 PM:     source: https://github.com/hazelcast/clc-docs (branch: v/5.4.0 | start path: docs)
```

https://app.netlify.com/sites/nifty-wozniak-71a44b/deploys/66e050c9b9be6f00084f11ce#L324