### PR TITLE
Fix build errors v/5.4.1

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -5,7 +5,7 @@ start_page: overview.adoc
 version: '5.4.1'
 # Version in the version selector (we display only the latest major.minor version)
 display_version: '5.4.1'
-# Displays a banner to inform users that this is a prerelease version 
+# Displays a banner to inform users that this is a prerelease version
 prerelease: false
 asciidoc:
   attributes:
@@ -17,6 +17,6 @@ asciidoc:
     page-toclevels: 3@
     # Required Go version for build
     go-version: 1.21
-    page-latest-supported-mc: '5.5-snapshot'
+    page-latest-supported-mc: '5.5'
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
Fixes

```
5:06:01 PM: [14:06:01.554] ERROR (asciidoctor): target of xref not found: 5.5-snapshot@management-center:clusters:clients.adoc
5:06:01 PM:     file: docs/modules/ROOT/pages/environment-variables.adoc
5:06:01 PM:     source: https://github.com/hazelcast/clc-docs (branch: v/5.4.1 | start path: docs)
```

https://app.netlify.com/sites/nifty-wozniak-71a44b/deploys/66e050c9b9be6f00084f11ce#L330