### PR TITLE
Use latest snapshot in main

### DIFF
--- a/check-links-playbook.yml
+++ b/check-links-playbook.yml
@@ -12,7 +12,9 @@ content:
   - url: https://github.com/hazelcast/hz-docs
     branches: [main]
     start_path: docs
-
+  - url: https://github.com/hazelcast/management-center-docs
+    branches: [main, v/5.5]
+    start_path: docs
 ui:
   bundle:
     url: https://github.com/hazelcast/hazelcast-docs-ui/releases/latest/download/ui-bundle.zip #../hazelcast-docs-ui/build/ui-bundle.zip

--- a/check-links-playbook.yml
+++ b/check-links-playbook.yml
@@ -6,14 +6,139 @@ content:
   - url: .
     branches: HEAD
     start_path: docs
-  - url: https://github.com/hazelcast/cloud-docs
-    branches: [ main ]
-    start_paths: [ docs, tutorials ]
   - url: https://github.com/hazelcast/hz-docs
     branches: [main]
     start_path: docs
+  - url: https://github.com/hazelcast/hazelcast-docs
+    branches: [ main ]
+    start_paths: [ home,tutorials ]
+  - url: https://github.com/hazelcast/imdg-docs
+    branches: [ main ]
+    start_path: docs
   - url: https://github.com/hazelcast/management-center-docs
-    branches: [main, v/5.5]
+    branches: [ main, v/5.5 ]
+    start_path: docs
+  - url: https://github.com/hazelcast/cloud-docs
+    branches: [ main ]
+    start_paths: [ docs, tutorials ]
+  - url: https://github.com/hazelcast/hazelcast-platform-operator-docs
+    branches: [ main ]
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/sql_stock_ticker_cloud
+    branches: master
+    start_paths: docs
+  - url: https://github.com/hazelcast-guides/client-failover
+    branches: master
+    start_paths: docs
+  - url: https://github.com/hazelcast-guides/spring-boot-sample
+    branches: master
+    start_paths: docs
+  - url: https://github.com/hazelcast-guides/serverless-fraud-detection
+    branches: master
+    start_paths: docs
+  - url: https://github.com/hazelcast-guides/write-through-cache-mongodb-mapstore
+    branches: master
+    start_paths: docs
+  - url: https://github.com/hazelcast-guides/standard-deviation-parallel-processing
+    branches: master
+    start_paths: docs
+  - url: https://github.com/hazelcast-guides/stream-to-stream-joins
+    branches: master
+    start_paths: docs
+  - url: https://github.com/hazelcast/hazelcast-cloud-maven-plugin
+    branches: main
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/adoc-templates.git
+    branches: antora-doc
+  - url: https://github.com/hazelcast-guides/caching-springboot-jcache
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/hazelcast-embedded-springboot
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/springboot-hibernate
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/hibernate-jcache
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/istio
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/caching-micronaut
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/kubernetes-embedded
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/hazelcast-embedded-microprofile
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/hazelcast-client-quarkus
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/springboot-webfilter-session-replication
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/caching-springboot
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/ecs-embedded
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/springboot-tomcat-session-replication
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/terraform-quickstarts
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/kubernetes-external-client
+    branches: main
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/active-directory-authentication
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/kubernetes-sidecar
+    branches: main
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/kubernetes-hpa
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/kubernetes-ssl
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/kubernetes-wan
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/kubernetes
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/spring-session-hazelcast
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/ec2-cluster
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/linkerd
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/consul
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/nodejs-client-getting-started
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/go-client-getting-started
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/openfaas-hz-client
+    branches: master
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/hazelcast-platform-operator-expose-externally
+    branches: main
+    start_path: docs
+  - url: https://github.com/hazelcast-guides/hazelcast-platform-operator-external-backup-restore
+    branches: master
     start_path: docs
 ui:
   bundle:

--- a/check-links-playbook.yml
+++ b/check-links-playbook.yml
@@ -2,12 +2,18 @@ site:
   title: Documentation
   url: http:localhost:5000
 content:
-  sources: 
+  sources:
   - url: .
     branches: HEAD
     start_path: docs
-    
-ui: 
+  - url: https://github.com/hazelcast/cloud-docs
+    branches: [ main ]
+    start_paths: [ docs, tutorials ]
+  - url: https://github.com/hazelcast/hz-docs
+    branches: [main]
+    start_path: docs
+
+ui:
   bundle:
     url: https://github.com/hazelcast/hazelcast-docs-ui/releases/latest/download/ui-bundle.zip #../hazelcast-docs-ui/build/ui-bundle.zip
     snapshot: true

--- a/check-links-playbook.yml
+++ b/check-links-playbook.yml
@@ -7,22 +7,22 @@ content:
     branches: HEAD
     start_path: docs
   - url: https://github.com/hazelcast/hz-docs
-    branches: [main]
+    branches: [main, v/5.5]
     start_path: docs
   - url: https://github.com/hazelcast/hazelcast-docs
-    branches: [ main ]
-    start_paths: [ home,tutorials ]
+    branches: [main]
+    start_paths: [home,tutorials]
   - url: https://github.com/hazelcast/imdg-docs
-    branches: [ main ]
+    branches: [main]
     start_path: docs
   - url: https://github.com/hazelcast/management-center-docs
-    branches: [ main, v/5.5 ]
+    branches: [main, v/5.5]
     start_path: docs
   - url: https://github.com/hazelcast/cloud-docs
-    branches: [ main ]
-    start_paths: [ docs, tutorials ]
+    branches: [main]
+    start_paths: [docs, tutorials]
   - url: https://github.com/hazelcast/hazelcast-platform-operator-docs
-    branches: [ main ]
+    branches: [main]
     start_path: docs
   - url: https://github.com/hazelcast-guides/sql_stock_ticker_cloud
     branches: master

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -5,7 +5,7 @@ start_page: overview.adoc
 version: '5.4.1'
 # Version in the version selector (we display only the latest major.minor version)
 display_version: '5.4.1'
-# Displays a banner to inform users that this is a prerelease version 
+# Displays a banner to inform users that this is a prerelease version
 prerelease: false
 asciidoc:
   attributes:
@@ -17,6 +17,6 @@ asciidoc:
     page-toclevels: 3@
     # Required Go version for build
     go-version: 1.21
-    page-latest-supported-mc: '6.0-snapshot'
+    page-latest-supported-mc: '5.5'
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -2,15 +2,15 @@ name: clc
 title: Hazelcast CLC
 start_page: overview.adoc
 # Version in the URL
-version: '5.5.0'
+version: 'latest-snapshot'
 # Version in the version selector (we display only the latest major.minor version)
-display_version: '5.5.0'
+display_version: 'latest-snapshot'
 # Displays a banner to inform users that this is a prerelease version
 prerelease: false
 asciidoc:
   attributes:
     # The full major.minor.patch version, which is used as a variable in the docs for things like download links
-    full-version: '5.5.0'
+    full-version: 'latest-snapshot'
     # Allows us to use UI macros. See https://docs.asciidoctor.org/asciidoc/latest/macros/ui-macros/
     experimental: true
     snapshot: true

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -17,6 +17,6 @@ asciidoc:
     page-toclevels: 3@
     # Required Go version for build
     go-version: 1.21
-    page-latest-supported-mc: '5.5'
+    page-latest-supported-mc: '5.6-snapshot'
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
All other docs repos use a special "snapshot" version in the `main` branch (e.g. [operator-docs](https://github.com/hazelcast/hazelcast-platform-operator-docs/blob/main/docs/antora.yml)).
It helps against a casual version collision (e.g. while [checking](https://github.com/hazelcast/clc-docs/actions/runs/11916108282/job/33207986644?pr=42) internal links) among branches.
This PR will have no impact on production docs, since we are using only `v/*` branches of this repo in docs